### PR TITLE
[hostname] contains invalid character '[' in CentOS 7

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -488,7 +488,7 @@ email_logfile()
       if [ ! -x "${MAILCMD}" ]; then
           echo -e "Email couldn't be sent. ${MAIL} not available." >&2
       else
-          EMAIL_SUBJECT=${EMAIL_SUBJECT:="duplicity-backup ${BACKUP_STATUS:-"ERROR"} [${HOSTNAME}] ${LOG_FILE}"}
+          EMAIL_SUBJECT=${EMAIL_SUBJECT:="duplicity-backup ${BACKUP_STATUS:-"ERROR"} (${HOSTNAME}) ${LOG_FILE}"}
           case ${MAIL} in
             ssmtp)
               mailcmd_ssmtp;;


### PR DESCRIPTION
`[hostname] contains invalid character '['` error in CentOS 7 changed [ to (

See https://www.jethrocarr.com/2012/06/10/mailx-contains-invalid-character-2/

There may be a better way to resolve this however this quick fix works