### PR TITLE
 Fix VERSION on macOS

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -130,7 +130,8 @@ version_compare "${DUPLICITY_VERSION}" 0.7
 case $? in 2) LT07=1;; *) LT07=0;; esac
 
 # Read the version string from the file VERSION
-DBSH_VERSION=$(<VERSION)
+DBSH_DIRPATH=$(dirname "$(readlink -f "$0")")
+DBSH_VERSION=$(<${DBSH_DIRPATH}/VERSION)
 
 version(){
   echo "duplicity-backup.sh ${DBSH_VERSION}"
@@ -900,9 +901,10 @@ check_variables
 
 echo -e "--------    START DUPLICITY-BACKUP SCRIPT for ${HOSTNAME}   --------\n" >&5
 
-echo -e "-------[ Program versions ]-------\n"
-echo -e "duplicity-backup.sh ${DBSH_VERSION}\n"
-echo -e "duplicity ${DUPLICITY_VERSION}\n"
+echo -e "-------[ Program versions ]-------"
+echo -e "duplicity-backup.sh ${DBSH_VERSION}"
+echo -e "duplicity ${DUPLICITY_VERSION}"
+echo -e "----------------------------------\n"
 
 get_lock
 

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -130,7 +130,11 @@ version_compare "${DUPLICITY_VERSION}" 0.7
 case $? in 2) LT07=1;; *) LT07=0;; esac
 
 # Read the version string from the file VERSION
-DBSH_DIRPATH=$(dirname "$(readlink -f "$0")")
+if [[ "$(uname)" == "Darwin" ]]; then
+  DBSH_DIRPATH=$(dirname "$(readlink "$0")")
+else
+  DBSH_DIRPATH=$(dirname "$(readlink -f "$0")")
+fi
 DBSH_VERSION=$(<${DBSH_DIRPATH}/VERSION)
 
 version(){


### PR DESCRIPTION
Fixes the following error on macOS:
~~~
$ duplicity-backup.sh -c hourly.com.conf -s
readlink: illegal option -- f
usage: readlink [-n] [file ...]
/usr/local/bin/duplicity-backup.sh: line 134: ./VERSION: No such file or directory
-------[ Program versions ]-------
duplicity-backup.sh
duplicity 0.7.14
----------------------------------
~~~