### PR TITLE
Telegram Notifications

### DIFF
--- a/duplicity-backup.conf.example
+++ b/duplicity-backup.conf.example
@@ -439,6 +439,10 @@ IFTTT_MAKER_EVENT="duplicity" # name the event to trigger at IFTTT Maker Channel
 IFTTT_HOOK_URL="https://maker.ifttt.com/trigger/$IFTTT_MAKER_EVENT/with/key/$IFTTT_KEY" # ONLY change this if IFTTT changes it
 IFTTT_VALUE2="" # general purpose value to pass to your maker channel (optional)
 
+# Provider: Telegram
+TELEGRAM_CHATID="" #Generate a Telegram bot following guide: https://core.telegram.org/bots#3-how-do-i-create-a-bot
+TELEGRAM_KEY=""
+
 # ------------------------------------------------------------------------------
 # TROUBLESHOOTING
 # ------------------------------------------------------------------------------

--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -569,6 +569,9 @@ send_notification()
       -F "message=${NOTIFICATION_CONTENT}" \
       https://api.pushover.net/1/messages
       echo -e "Pushover notification sent"
+    elif [ "${NOTIFICATION_SERVICE}" = "telegram" ]; then
+        curl -s --max-time 10 -d "chat_id=$TELEGRAM_CHATID&disable_web_page_preview=1&text=$NOTIFICATION_CONTENT" "https://api.telegram.org/bot$TELEGRAM_KEY/sendMessage" >/dev/null
+      echo -e "Telegram notification sent"
     fi
   fi
 }


### PR DESCRIPTION
Hi @zertrin,

I've added Telegram notifications to duplicity-backup.sh. I tested and everything works ok. 

If you want to test it, you can follow the guide to create a Telegram Bot: https://core.telegram.org/bots#3-how-do-i-create-a-bot and then add in config file the chatID and Key to test.

Thanks for the hard work on the duplicity-backup.sh
Gerard.