### PR TITLE
Use regex for trimming file:// destinations

### DIFF
--- a/duplicity-backup.sh
+++ b/duplicity-backup.sh
@@ -650,7 +650,7 @@ get_remote_file_size()
     ;;
     "fi")
       FRIENDLY_TYPE_NAME="File"
-      TMPDEST=$(echo "${DEST}" | cut -c 6-)
+      TMPDEST="${DEST#file://*}"
       SIZE=$(du -hs "${TMPDEST}" | awk '{print $1}')
     ;;
     "gs")


### PR DESCRIPTION
A problem with cut was causing:

```shell
  $ DEST="file:///media/user/data"
  $ TMPDEST=$(echo "${DEST}" | cut -c 6-)
  $ echo $TMPDEST
  ///media/user/data
```

The fix uses a regex instead so that we trim away things correctly. It also seems somewhat more
readable.